### PR TITLE
Update egimff.py

### DIFF
--- a/phypno/ioeeg/egimff.py
+++ b/phypno/ioeeg/egimff.py
@@ -1,3 +1,4 @@
+import io
 from datetime import datetime
 from glob import glob
 from logging import getLogger
@@ -154,7 +155,7 @@ class EgiMff:
             except IndexError:
                 endrec = len(x)
 
-            f = open(self._signal[one_signal], 'rb')
+            f = io.open(self._signal[one_signal], 'rb')
 
             i0 = 0
             for rec in range(begrec, endrec + 1):


### PR DESCRIPTION
Reading binary from io.open() is faster. On my setup, with this small change, _read_block() calls takes half the time it was taking before.